### PR TITLE
Brush link bar chart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/index.html
+++ b/index.html
@@ -47,11 +47,14 @@
     
     <h1>Visualization</h1>
     
-    <p><em>Include the interactive visualization as part of this page. Static example follows.</em></p>
+    <p><em>Interact with the graphs by clicking on the scatterplot points or brushing over them to select one or more countries. The bar charts will update to show data for the selected countries. If you click on a country, an extra bar graph will display infrastructure investment for that country. Use the "Clear Selection" button to reset the selection.</em></p>
     
   </div>
   
   <!-- Your visualization here -->
+  <div class="clear-button-container">
+    <button id="clear-button">Clear Selection</button>
+  </div>
   <div class="vis-container">
     <div class="scatterplot-container">
       <svg id="scatterplot" preserveAspectRatio="xMidYMid meet" class="marks" viewBox="0 0 750 500" width="100%" height="100%"></svg>

--- a/index.html
+++ b/index.html
@@ -61,6 +61,9 @@
       <svg id="bar-graph-2" width="100%" height="50%"></svg>
     </div>
   </div>
+  <div class="bar-chart-container">
+    <svg id="bar-chart" width="70%" height="100%"></svg>
+  </div>
   
   <!-- Your writeup goes here -->
   <div class = "content-column">

--- a/index.html
+++ b/index.html
@@ -52,15 +52,14 @@
   </div>
   
   <!-- Your visualization here -->
-  <div class="vis-holder">
-    <!-- Change viewbox to whatever you want, e.g. "0 0 1000 6000" This determines your aspect ratio and coordinate system -->    
-    <!-- Delete all the sample SVG code below after the viewbox to before the closing tag. Populate this part of the SVG with D3. -->
-    <svg id="scatterplot"
-      preserveAspectRatio="xMidYMid meet" class="marks" viewBox="0 0 821 520" width="70%" height ="60%">  
-     
-    <!-- Don't delete the closing tag! -->
-    </svg>
-     <svg id="bar-container" width="70%" height ="60%"></svg>
+  <div class="vis-container">
+    <div class="scatterplot-container">
+      <svg id="scatterplot" preserveAspectRatio="xMidYMid meet" class="marks" viewBox="0 0 750 500" width="100%" height="100%"></svg>
+    </div>
+    <div class="bar-graphs-container">
+      <svg id="bar-graph-1" width="100%" height="50%"></svg>
+      <svg id="bar-graph-2" width="100%" height="50%"></svg>
+    </div>
   </div>
   
   <!-- Your writeup goes here -->
@@ -122,6 +121,7 @@
   <script src="lib/d3.v4/d3.v4.js"></script>
   <script src="js/scatterplot.js"></script>
   <script src="js/countryBar.js"></script>
+  <script src="js/countryBarGraphs.js"></script>
   <script src="js/visualization.js"></script>
 </body>
 </html>

--- a/js/countryBar.js
+++ b/js/countryBar.js
@@ -46,7 +46,7 @@ function countryBar() {
             .attr("y", height / 4 - 10)  // Position the text above the bar
             .attr("text-anchor", "middle")
             .attr("font-size", "16px")
-            .text("Percentage of Infrastructure Spending on Maintenance");
+            .text(countryData.country + " % of Infrastructure Spending on Maintenance");
 
         // Title for maintenance section
         chartGroup.append("text")
@@ -73,6 +73,14 @@ function countryBar() {
             .attr("font-size", "11px")
             .attr("fill", "white")
             .text(`${(otherPercentage * 100).toFixed(1)}%`);
+
+        // Add the percentage text for the other section (blue)
+        chartGroup.append("text")
+            .attr("x", width * (maintenancePercentage + otherPercentage / 2))
+            .attr("y", height / 1 + 10)  // Position the text below the bar
+            .attr("text-anchor", "middle")
+            .attr("font-size", "11px")
+            .text("Other");
 
         return chart;
     }

--- a/js/countryBarGraphs.js
+++ b/js/countryBarGraphs.js
@@ -1,0 +1,102 @@
+function countryBarGraphs() {
+    let margin = { top: 20, left: 100, right: 30, bottom: 50 },
+        width = 750 - margin.left - margin.right,
+        height = 250 - margin.top - margin.bottom; // Half the height of the scatterplot
+
+    const dispatcher = d3.dispatch("selectionUpdated");
+
+    function chart(selector, data, xValue, xLabel) {
+        // Sort data by xValue
+        data.sort((a, b) => xValue(a) - xValue(b));
+
+        const svg = d3.select(selector)
+            .attr("viewBox", `0 0 ${width + margin.left + margin.right} ${height + margin.top + margin.bottom}`)
+            .classed("svg-content", true);
+
+        let chartGroup = svg.select("g");
+        if (chartGroup.empty()) {
+            chartGroup = svg.append("g")
+                .attr("transform", `translate(${margin.left}, ${margin.top})`);
+        }
+
+        // Clear previous chart elements to avoid overlap
+        chartGroup.selectAll("*").remove();
+
+        // Define scales
+        const yScale = d3.scaleBand()
+            .domain(data.map(d => d.country))
+            .range([height, 0])
+            .padding(0.1);
+
+        const xScale = d3.scaleLinear()
+            .domain([0, d3.max(data, xValue)])
+            .range([0, width]);
+
+        // Create axes
+        chartGroup.append("g")
+            .attr("transform", `translate(0, ${height})`)
+            .call(d3.axisBottom(xScale).tickFormat(d => {
+                if (d >= 1e9) return (d / 1e9).toFixed(1) + "B";
+                if (d >= 1e6) return (d / 1e6).toFixed(1) + "M";
+                if (d >= 1e3) return (d / 1e3).toFixed(1) + "K";
+                return d;
+            })); // Custom format for large numbers
+
+        chartGroup.append("g")
+            .call(d3.axisLeft(yScale));
+
+        // Create bars
+        const bars = chartGroup.selectAll(".bar")
+            .data(data)
+            .enter().append("rect")
+            .attr("class", "bar")
+            .attr("x", 0)
+            .attr("y", d => yScale(d.country))
+            .attr("width", d => xScale(xValue(d)))
+            .attr("height", yScale.bandwidth())
+            .attr("fill", "steelblue")
+            .on("click", function(event, d) {
+                // Toggle selection on click
+                const isSelected = d3.select(this).classed("selected");
+                d3.select(this).classed("selected", !isSelected)
+                    .attr("fill", !isSelected ? "green" : "steelblue");
+
+                // Dispatch the selectionUpdated event with the selected data
+                const selectedData = chartGroup.selectAll(".bar.selected").data();
+                dispatcher.call("selectionUpdated", this, selectedData);
+
+            });
+
+        // Add x-axis label
+        chartGroup.append("text")
+            .attr("class", "axisLabel")
+            .attr("x", width / 2)
+            .attr("y", height + margin.bottom - 10)
+            .style("text-anchor", "middle")
+            .text(xLabel);
+
+        return chart;
+    }
+
+    // Gets or sets the dispatcher we use for selection events
+    chart.selectionDispatcher = function (_) {
+        if (!arguments.length) return dispatcher;
+        dispatcher = _;
+        return chart;
+    };
+
+    // Given selected data from another visualization 
+    // select the relevant elements here (linking)
+    chart.updateSelection = function (selectedData) {
+        if (!arguments.length) return;
+
+        // Select an element if its datum was selected
+        d3.selectAll('.bar').classed("selected", function(d) {
+            const isSelected = selectedData.includes(d);
+            d3.select(this).attr("fill", isSelected ? "green" : "steelblue");
+            return isSelected;
+        });
+    };
+
+    return chart;
+}

--- a/js/scatterplot.js
+++ b/js/scatterplot.js
@@ -106,9 +106,9 @@ function scatterplot() {
     points = points.enter()
       .append("circle")
       .attr("class", "point scatterPoint")
-    .merge(points)
-    .attr("cx", X)
-    .attr("cy", Y)
+      .merge(points)
+      .attr("cx", X)
+      .attr("cy", Y)
       .attr("r", d => sizeScale(d.population))
       .attr("fill", d => colorScale(d.country))
       .on("mouseover", function() {

--- a/js/scatterplot.js
+++ b/js/scatterplot.js
@@ -83,8 +83,7 @@ function scatterplot() {
         );
 
         let dispatchString = Object.getOwnPropertyNames(dispatcher._)[0];
-        console.log(svg.selectAll(".selected").data());
-
+       
         dispatcher.call(dispatchString, this, svg.selectAll(".selected").data());
       }
 
@@ -256,12 +255,16 @@ function scatterplot() {
     return chart;
   };
 
-  // Update the selection based on selected data
+  // Given selected data from another visualization 
+  // select the relevant elements here (linking)
   chart.updateSelection = function (selectedData) {
     if (!arguments.length) return;
+
+    // Select an element if its datum was selected
     selectableElements.classed("selected", d => {
-      return selectedData.some(sd => sd.country === d.country);
+      return selectedData.includes(d)
     });
+
   };
 
   return chart;

--- a/js/visualization.js
+++ b/js/visualization.js
@@ -45,6 +45,8 @@
           }
         ];
         countryBarChart("#bar-container", countryBarData);
+        barGraph1.updateSelection([countryData]);
+        barGraph2.updateSelection([countryData]);
       } else {
         countryBarChart("#bar-container");
         console.log("Missing required data for the selected country");

--- a/js/visualization.js
+++ b/js/visualization.js
@@ -30,7 +30,7 @@
       barGraph1.updateSelection(selectedData);
     });
 
-    // Handle country selection
+    // When clicking on a scatterplot point, update the countryBar.js bar and countryBarGraphs.js bar charts
     scatter.selectionDispatcher().on(countrySelectedString, function(countryName) {
       // Find the data for the selected country
       const countryData = data.find(d => d.country === countryName);
@@ -44,11 +44,11 @@
             infrastructureMaintenance: countryData.infrastructureMaintenance
           }
         ];
-        countryBarChart("#bar-container", countryBarData);
+        countryBarChart("#bar-chart", countryBarData);
         barGraph1.updateSelection([countryData]);
         barGraph2.updateSelection([countryData]);
       } else {
-        countryBarChart("#bar-container");
+        countryBarChart("#bar-chart");
         console.log("Missing required data for the selected country");
       }
     });

--- a/js/visualization.js
+++ b/js/visualization.js
@@ -61,5 +61,12 @@
       barGraph1.updateSelection(selectedData);
       barGraph2.updateSelection(selectedData);
     });
+
+    document.getElementById("clear-button").addEventListener("click", function() {
+      scatter.updateSelection([]);
+      barGraph1.updateSelection([]);
+      barGraph2.updateSelection([]);
+      countryBarChart("#bar-chart", []);
+    });
   });
 })();

--- a/js/visualization.js
+++ b/js/visualization.js
@@ -13,9 +13,25 @@
       .selectionDispatcher(d3.dispatch(dispatchString, countrySelectedString)) // Register both events
     ("#scatterplot", data);
 
-    // Listen to the "countrySelected" event after initializing scatterplot
-    scatter.selectionDispatcher().on("countrySelected", function(countryName) {
+    // Initialize the bar graphs
+    const barGraph1 = countryBarGraphs();
+    const barGraph2 = countryBarGraphs();
 
+    barGraph1("#bar-graph-1", data, d => d.railUsageTotalPassengers2022 / d.population, "Rail Passengers per Capita");
+    barGraph2("#bar-graph-2", data, d => d.infrastructureInvestment, "Transportation Investment");
+
+    barGraph1.selectionDispatcher().on(dispatchString, (selectedData) => {
+      scatter.updateSelection(selectedData);
+      barGraph2.updateSelection(selectedData);
+    });
+
+    barGraph2.selectionDispatcher().on(dispatchString, (selectedData) => {
+      scatter.updateSelection(selectedData);
+      barGraph1.updateSelection(selectedData);
+    });
+
+    // Handle country selection
+    scatter.selectionDispatcher().on(countrySelectedString, function(countryName) {
       // Find the data for the selected country
       const countryData = data.find(d => d.country === countryName);
 
@@ -39,7 +55,9 @@
     const countryBarChart = countryBar();
 
     // Handle selection updates
-    scatter.selectionDispatcher().on("selectionUpdated", (selectedData) => {
+    scatter.selectionDispatcher().on(dispatchString, (selectedData) => {
+      barGraph1.updateSelection(selectedData);
+      barGraph2.updateSelection(selectedData);
     });
   });
 })();

--- a/style.css
+++ b/style.css
@@ -21,6 +21,28 @@ h1, h2, h3 {
   height: 100%;
 }
 
+.vis-container {
+  display: flex;
+  justify-content: space-between;
+  align-items: center; /* Center vertically */
+  width: 100%;
+  height: 100%;
+}
+
+.scatterplot-container {
+  width: 55%; /* Make scatter plot smaller */
+  height: 100%;
+}
+
+.bar-graphs-container {
+  width: 50%; /* Make bar graphs bigger */
+  height: 80%; /* Adjust height to center vertically */
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  align-items: center; /* Center horizontally */
+}
+
 /*I added this*/
 .point {
 	stroke-width: 3;

--- a/style.css
+++ b/style.css
@@ -29,6 +29,47 @@ h1, h2, h3 {
   height: 100%;
 }
 
+.clear-button-container {
+  display: flex;
+  justify-content: center; /* Center horizontally */
+  align-items: center; /* Center vertically */
+  width: 100%;
+  height: 20%;
+}
+
+#clear-button {
+  align-items: center;
+  background-color: #FFE7E7;
+  background-position: 0 0;
+  border: 1px solid #FEE0E0;
+  border-radius: 11px;
+  box-sizing: border-box;
+  color: #D33A2C;
+  cursor: pointer;
+  display: flex;
+  font-size: 1rem;
+  font-weight: 700;
+  line-height: 33.4929px;
+  padding: 2px 12px;
+  text-align: left;
+  text-underline-offset: 1px;
+  transition: border .2s ease-in-out,box-shadow .2s ease-in-out;
+  touch-action: manipulation;
+  white-space: nowrap;
+  word-break: break-word;
+}
+
+#clear-button:hover {
+  background-color: #FFE3E3;
+  border-color: #FAA4A4;
+}
+
+#clear-button:active:hover {
+  background-color: #D33A2C;
+  box-shadow: rgba(0, 0, 0, 0.12) 0 1px 3px 0 inset;
+  color: #FFFFFF;
+}
+
 .scatterplot-container {
   width: 55%; /* Make scatter plot smaller */
   height: 100%;
@@ -51,25 +92,22 @@ h1, h2, h3 {
   height: 100%
 }
 
-/*I added this*/
 .point {
 	stroke-width: 3;
-  }
+}
 
-  /* I added this for showing which point is hovered over */
 circle.mouseover {
 	fill: pink;
 	stroke: red;
 	opacity: 5;
-  }
+}
 
-  /* Shows which point is being looked at */
-  circle.selected {
+circle.selected {
 	fill: green;
-	stroke: white;
+	stroke: red;
+	stroke-width: 4px;
 	opacity: 5;
-  }
-
+}
 
 .countryLabel {
    font-size: 12px;

--- a/style.css
+++ b/style.css
@@ -43,6 +43,14 @@ h1, h2, h3 {
   align-items: center; /* Center horizontally */
 }
 
+.bar-chart-container {
+  display: flex;
+  justify-content: center; /* Center horizontally */
+  align-items: center; /* Center vertically */
+  width: 100%;
+  height: 100%
+}
+
 /*I added this*/
 .point {
 	stroke-width: 3;


### PR DESCRIPTION
- Fixed brushing issue as described by Aaron with the scatterplot and the countryBar.js element

- Added side bar graphs with brushing and linking with the scatterplot

- Made scatter plot points more clear when selected/highlighted by increasing the thickness of the outline and changed outline color to red

- Moved countryBar.js element to a separate div component to place below scatter plot and bar graphs

- Added a "clear selection" button to give users an easy way to clear all selections

- Changed title of countryBar.js name to include country name

- Added "Other" label for spending other than maintenance spending in countryBar.js