### PR TITLE
Add mouse over highlighting for bar chart

### DIFF
--- a/js/countryBarGraphs.js
+++ b/js/countryBarGraphs.js
@@ -65,6 +65,23 @@ function countryBarGraphs() {
                 const selectedData = chartGroup.selectAll(".bar.selected").data();
                 dispatcher.call("selectionUpdated", this, selectedData);
 
+            })
+            .on("mouseover", function() {
+                const isSelected = d3.select(this).classed("selected");
+                d3.select(this)
+                    .attr("stroke", "red")
+                    .attr("stroke-width", 1);
+                if (!isSelected) {
+                    d3.select(this).attr("fill", "pink");
+                };
+            })
+            .on("mouseout", function() {
+                const isSelected = d3.select(this).classed("selected");
+                d3.select(this)
+                    .attr("stroke", "none");
+                if (!isSelected) {
+                    d3.select(this).attr("fill", "steelblue");
+                };
             });
 
         // Add x-axis label


### PR DESCRIPTION
When hovering over bars in the bar chart, the bar will become highlighted pink with a red border to indicate a selectable element similar to the scatterplot. The colors are the same to maintain consistency. Addtionally, already highlighted green bars will not become pink and will only get a red outline which mimics the scatter plot highlight behavior.